### PR TITLE
make deparse use Data::Dumper for constants

### DIFF
--- a/lib/eval.pl
+++ b/lib/eval.pl
@@ -179,7 +179,7 @@ no warnings;
 
       if( $@ ) { print STDOUT "Error: $@"; return }
 
-      my $dp = B::Deparse->new("-p", "-q", "-x7");
+      my $dp = B::Deparse->new("-p", "-q", "-x7", "-d");
 
       my @out;
 


### PR DESCRIPTION
The built-in dumper in B::Deparse doesn't handle cyclic constants (and recurses infinitely). For example:

    deparse: use constant FOO => do { my %x; $x{k} = \%x }; FOO

This problem also occurs if you try to deparse parameter types with Function::Parameters and Types::Standard.